### PR TITLE
get_grapheme_cluster_break_tests_as_UTF8 can break when locale isn't UTF-8

### DIFF
--- a/utils/GYBUnicodeDataUtils.py
+++ b/utils/GYBUnicodeDataUtils.py
@@ -548,7 +548,7 @@ def get_grapheme_cluster_break_tests_as_UTF8(grapheme_break_test_file_name):
 
     result = []
 
-    with codecs.open(grapheme_break_test_file_name, encoding=sys.getfilesystemencoding(), errors='strict') as f:
+    with codecs.open(grapheme_break_test_file_name, encoding='utf-8'), errors='strict') as f:
         for line in f:
             test = _convert_line(line)
             if test:


### PR DESCRIPTION

When codecs.open is called encoding needs to be utf8 instead of
a query of getfilesystemencoding() as it could be ascii.